### PR TITLE
week5 / sanghoon / Java

### DIFF
--- a/week 5/1003_sanghoon.java
+++ b/week 5/1003_sanghoon.java
@@ -1,0 +1,29 @@
+import java.io.*;
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int T = Integer.parseInt(br.readLine());
+        while (T-->0){
+            int N = Integer.parseInt(br.readLine());
+            int[][] dp = new int[N+1][2];
+            dp[0][0] = 1;
+            dp[0][1] = 0;
+            if(N>0){
+                dp[1][0] = 0;
+                dp[1][1] = 1;
+                for(int i=2; i<=N; i++){
+                    dp[i][0] = dp[i-2][0] + dp[i-1][0];
+                    dp[i][1] = dp[i-2][1] + dp[i-1][1];
+                }
+            }
+            bw.write(String.valueOf(dp[N][0] +" " + dp[N][1] +"\n"));
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}

--- a/week 5/11399_sanghoon.java
+++ b/week 5/11399_sanghoon.java
@@ -1,0 +1,31 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int N = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int[] pi = new int[N];
+        for(int i=0; i<N; i++){
+            pi[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // sol
+        Arrays.sort(pi);
+        int prev = 0;
+        int answer = 0;
+        for(int i=0; i<N; i++) {
+            answer += pi[i] + prev;
+            prev += pi[i];
+        }
+
+        bw.write(String.valueOf(answer));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}

--- a/week 5/1654_sanghoon.java
+++ b/week 5/1654_sanghoon.java
@@ -1,0 +1,38 @@
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int K = Integer.parseInt(st.nextToken());
+        int N = Integer.parseInt(st.nextToken());
+        int max_value = Integer.MIN_VALUE;
+        int[] arr = new int[K];
+        for(int i=0; i<K; i++){
+            arr[i] = Integer.parseInt(br.readLine());
+            max_value = Math.max(arr[i], max_value);
+        }
+        long lt = 1;
+        long rt = max_value;
+        long result = -1;
+        while (lt<=rt){
+            long mid = (lt+rt)/2;
+            int cnt = 0;
+            for(int i=0; i<K; i++){
+                cnt += arr[i]/mid;
+            }
+            if(cnt<N){
+                rt = mid-1;
+            } else if (cnt>=N) {
+                lt = mid+1;
+                result = Math.max(result, mid);
+            }
+        }
+        bw.write(String.valueOf(result));
+        bw.close();
+        br.close();
+    }
+}

--- a/week 5/2156_sanghoon.java
+++ b/week 5/2156_sanghoon.java
@@ -1,0 +1,27 @@
+import java.io.*;
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[10000];
+        int[] dp = new int[10000];
+        for(int i=0; i<n; i++){
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+        dp[0] = arr[0];
+        dp[1] = arr[0]+arr[1];
+        dp[2] = Math.max(arr[0]+arr[2], arr[1]+arr[2]);
+        dp[2] = Math.max(arr[0]+arr[1], dp[2]);
+        for(int i=3; i<n; i++){
+            int tem = Math.max(dp[i-3]+arr[i-1]+arr[i], dp[i-2]+arr[i]);
+            dp[i] = Math.max(tem, dp[i-1]);
+        }
+
+        bw.write(String.valueOf(dp[n-1]));
+
+        bw.close();
+        br.close();
+    }
+}

--- a/week 5/4673_sanghoon.java
+++ b/week 5/4673_sanghoon.java
@@ -1,0 +1,23 @@
+import java.io.*;
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        boolean [] check = new boolean[10001];
+        for(int i=1; i<=10000; i++){
+            int sum = i;
+            String str = String.valueOf(i);
+            for(char ch : str.toCharArray()){
+                sum += ch-'0';
+            }
+            if(sum<=10000)
+                check[sum] = true;
+        }
+        for(int i=1; i<=10000; i++){
+            if(check[i]==false){
+                System.out.println(i);
+            }
+        }
+        br.close();
+    }
+}


### PR DESCRIPTION
## ✏️ 풀이 문제 목록

- BOJ 4673 - 셀프 넘버 - 실버 5 - O
- BOJ 11399 - ATM - 실버 4 - O
- BOJ 1003 - 피보나치 함수 - 실버 3 - O
- BOJ 1654 - 랜선 자르기 - 실버 2 - O
- BOJ 2156 - 포도주 시식 - 실버 1 - O

## BOJ 4673 - 셀프 넘버 - 실버 5

### 코드 설명
1부터 10,000까지 boolean[] check 배열을 만든다. 그리고 1부터 10,000까지 순차탐색 하면서 셀프 넘버인지를 판별한다. 셀프 넘버가 아니라면 check 배열의 값을 true로 설정한다. 마지막에 check 배열에서 값이 false인(셀프 넘버) 숫자들을 출력한다. 

### 시간 복잡도 계산
O(N)

## BOJ 11399 - ATM - 실버 4

### 코드 설명
어떻게 줄을 서야 결과값이 최소가 될까? 돈을 인출하는데 걸리는 시간이 짧은 순서대로 줄을 서야 최소가 된다. 따라서 Pi 배열을 오름차순으로 정렬시키고 시간의 합을 구하면 된다.
### 시간 복잡도 계산
O(NlogN)
## BOJ 1003 - 피보나치 함수 - 실버 3

### 코드 설명
피보나치 수열 문제로 재귀를 사용하면 시간초과 판정이 뜬다. 따라서 dp를 사용한다. dp의 점화식은 아래와 같다. 
dp[i][0] = dp[i-2][0] + dp[i-1][0];
dp[i][1] = dp[i-2][1] + dp[i-1][1];
(dp[i][0] : 정수 i를 호출할 때 호출되는 0의 횟수, dp[i][1] : 정수 i를 호출할 때 호출되는 1의 횟수)
### 시간 복잡도 계산
O(TN)
## BOJ 1654 - 랜선 자르기 - 실버 2

### 코드 설명
매개변수 탐색 유형의 문제다. 초기값을 lt = 1, rt = arr 배열의 최대값으로 설정한 후 조건에 맞는 값을 이분 탐색을 통해 찾으면 된다. 
### 시간 복잡도 계산
O(KlogM) (M : arr 배열의 최대값)
## BOJ 2156 - 포도주 시식 - 실버 1

### 코드 설명
dp 문제다. 점화식은 아래와 같다.
dp[i] : i번째 와인까지 따졌을 때 마실 수 있는 와인의 최대량
dp[i] = MAX(dp[i-1], dp[i-3]+arr[i-1]+arr[i], dp[i-2]+arr[i]);
### 시간 복잡도 계산
O(N)