### PR TITLE
week5 / nagyum / python

### DIFF
--- a/week 5/1003_nagyum.py
+++ b/week 5/1003_nagyum.py
@@ -1,0 +1,8 @@
+t=int(input())
+
+for _ in range(t):
+    n=int(input())
+    a,b=1,0
+    for i in range (n):
+        a,b=b,a+b
+    print(a,b)

--- a/week 5/11399_nagyum.py
+++ b/week 5/11399_nagyum.py
@@ -1,0 +1,10 @@
+n=int(input())
+time_list=list(map(int,input().split()))
+
+time_list.sort()
+a=0
+
+for i in range(1,n+1):
+    a += sum(time_list[0:i])
+    
+print(a)

--- a/week 5/1654_nagyum.py
+++ b/week 5/1654_nagyum.py
@@ -1,0 +1,19 @@
+K,N=map(int,input().split())
+len=[]
+for _ in range (K):
+    len.append(int(input()))
+
+len.sort()   
+start=1
+end=max(len)
+
+while start <= end:
+    mid=(start+end)//2
+    line=0
+    for i in len:
+        line += i//mid
+    if line >=N:
+        start=mid+1
+    else:
+        end=mid-1
+print(end)

--- a/week 5/1654_nagyum.py
+++ b/week 5/1654_nagyum.py
@@ -3,7 +3,6 @@ len=[]
 for _ in range (K):
     len.append(int(input()))
 
-len.sort()   
 start=1
 end=max(len)
 

--- a/week 5/2156_nagyum.py
+++ b/week 5/2156_nagyum.py
@@ -1,0 +1,17 @@
+n=int(input())
+arr=[0]*10000 #각 포도주의 양
+for i in range(n):
+    arr [i]=int(input())
+    
+drink=[0]*10000 #최대로 마실 수 있는 포도주의 양
+drink[0]=arr[0] # 첫번째 잔의 양이 최대
+drink[1]=arr[0]+arr[1] #두번째까지 마신 양이 최대 양
+drink[2]=max(arr[2]+arr[1],arr[2]+arr[0],drink[1])
+#세잔을 연속으로 마실 수 없다고 했으니까 나올 수 있는 세가지 경우의 수 중에 최대
+
+for i in range (3,n): 
+    drink[i]=max(arr[i]+arr[i-1]+drink[i-3],arr[i]+drink[i-2],drink[i-1])
+#i번째 포도주를 안 마실 때: drink[i-1]는 이전상태에서의 최대양
+#i번째 포도주를 마실고 i-1은 안 마실 때 : arr[i]+drink[i-2]는 현재 포도주와 i-2번째까지의 최대
+#i번째 포도주를 마시고 i-1번째 포도주도 마실 때 : arr[i]+arr[i-1]과 세잔 연속은 안되니 i-3번째까지 마셨을 때 최대값
+print(max(drink))

--- a/week 5/4673_nagyum.py
+++ b/week 5/4673_nagyum.py
@@ -1,0 +1,12 @@
+arr=list(range(1,10001)) 
+rm_arr=[]
+
+for num in arr:
+    for n in str(num):
+        num += int(n)
+    if num <= 10000:
+        rm_arr.append(num)
+for rm_num in set(rm_arr):
+    arr.remove(rm_num)
+for self_num in arr:
+    print(self_num)


### PR DESCRIPTION
## ✏️ 풀이 문제 목록

BOJ 4673 - 셀프 넘버 - 실버 5 - O
BOJ 11399 - ATM - 실버 4 - O
BOJ 1003 - 피보나치 함수 - 실버 3 - O
BOJ 1654 - 랜선 자르기 - 실버 2 - O
BOJ 2156 - 포도주 시식 - 실버 1 - O


## BOJ 4673 - 셀프 넘버 - 실버 5

### 코드 설명

셀프넘버 = 어떠한 수와 어떠한 수의 합으로 만들어지지 않는 수
10000까지의 리스트 생성 후, 자신과 그 자신의 자릿수의 합이 되는 것을 리스트에서 제거한다

### 시간 복잡도 계산
O(N*M)
## BOJ 11399 - ATM  - 실버 4

### 코드 설명
ATM에서 걸리는 시간을 최소로 할려면 시간이 가장 적게 걸리는 사람부터 사용을 하면 된다. 그래서 걸리는 시간을 오름차순으로 정리한 뒤, 총 소요 시간을 구하면 된다.
### 시간 복잡도 계산
O(logN)+O(N^2)

## BOJ 1003 - 피보나치 함수 - 실버 3

### 코드 설명
0과 1이 출력되는 규칙을 구할 수 있는데,
i번째 0 = i-1번째 1 
i번째 1= i-1번째 0 + i-1번째 1 이라는 것을 알 수 있다.

### 시간 복잡도 계산
O(TN)

## BOJ 1654 - 랜선 자르기  - 실버 2

### 코드 설명
이분 탐색을 사용하면 된다. start값이 end값보다 작은 동안 이분탐색을 진행하면 된다.
### 시간 복잡도 계산
O(logK)

## BOJ 2156 - 포도주 시식 - 실버 1

### 코드 설명
각 포도주의 양을 입력받는 배열(arr)과 최대로 마실 수 있는 포도주(drink)의 배열을 만들어준다.
첫번째 포도주까지의 최대 (drink[0]) = 첫번째 포도주 잔이 최대(arr[0])
두번째 포도주까지의 최대 (drink[1]) = 첫번째 + 두번째 포도주 잔이 최대(arr[0]+arr[1])
세번째 포도주까지의 최대 (drink[2]) =  두번째 포도주까지의 최대 (drink[1]) / 첫번째 포도주과 세번째 포도주 잔 (arr[0]+arr[2]) / 두번째 포도주와 세번째 포도주 잔 (arr[1]+arr[2])

이 되는데 이를 통해 규칙을 알 수 있다. 
i번째 포도주를 안 마실 때: drink[i-1]는 이전상태에서의 최대양
i번째 포도주를 마실고 i-1은 안 마실 때 : arr[i]+drink[i-2]는 현재 포도주와 i-2번째까지의 최대
i번째 포도주를 마시고 i-1번째 포도주도 마실 때 : arr[i]+arr[i-1]과 세잔 연속은 안되니 i-3번째까지 마셨을 때 최대값
세가지의 경우중 최대를 출력하면 된다. 

### 시간 복잡도 계산
O(N)
