### PR TITLE
week6 / nagyum / pyhton

### DIFF
--- a/nagyum/week6/11047.py
+++ b/nagyum/week6/11047.py
@@ -1,0 +1,13 @@
+n,k=map(int,input().split())
+coin=[]
+count =0
+
+for i in range(n):
+    coin.append(int(input()))
+    
+coin=sorted(coin,reverse=True)
+
+for i in coin:
+    count += k//i
+    k %= i
+print(count)

--- a/nagyum/week6/11726.py
+++ b/nagyum/week6/11726.py
@@ -1,0 +1,14 @@
+import sys
+input = sys.stdin.readline
+
+n=int(input())
+dp=[0]*1001 # n+1로 주면 index 에러
+
+dp[1]=1
+dp[2] = 2
+
+
+for i in range(3,n+1):
+    dp[i]=(dp[i-1]+dp[i-2])%10007
+    
+print(dp[n])

--- a/nagyum/week6/1316.py
+++ b/nagyum/week6/1316.py
@@ -1,0 +1,13 @@
+n=int(input())
+count=0
+
+for i in range (n):
+    word=input()
+    for j in range (len(word)-1):
+        if word[j] != word[j+1]:
+           diff = word[j+1:]
+           if word[j] in diff:
+               count -= 1
+               break
+    count +=1
+print(count)

--- a/nagyum/week6/14889.py
+++ b/nagyum/week6/14889.py
@@ -1,0 +1,27 @@
+import sys
+input = sys.stdin.readline
+n=int(input())
+graph = [ list(map(int, sys.stdin.readline().split())) for _ in range(n) ]
+visit = [ False for _ in range(n) ] #1
+min_value = sys.maxsize #2
+
+def backTracking(depth, idx): #3
+    global min_value
+    if depth == n // 2: #4
+        power1, power2 = 0, 0
+        for i in range(n):
+            for j in range(n):
+                if visit[i] and visit[j]: #5
+                    power1 += graph[i][j]
+                elif not visit[i] and not visit[j]: #6
+                    power2 += graph[i][j]
+        min_value = min(min_value, abs(power1-power2)) #7
+        return
+
+    for i in range(idx, n): #8
+        if not visit[i]:
+            visit[i] = True
+            backTracking(depth+1, i+1) #9
+            visit[i] = False
+backTracking(0, 0)
+print(min_value)

--- a/nagyum/week6/4948.py
+++ b/nagyum/week6/4948.py
@@ -1,0 +1,47 @@
+"""from math import sqrt
+
+while True:
+    n=int(input())
+    
+    if n ==0:
+        break
+    
+    count=0
+    
+    for i in range (1,2*n+1):
+        if i ==1:
+            continue
+        if i==2:
+            count +=1
+            continue
+        else:
+            for j in range(2,int(i**0.5)+1):
+                if i %j==0:
+                    break
+                else:
+                    count +=1
+    print(count)
+    """
+
+from math import sqrt
+
+while True:
+    n = int(input())
+    
+    if n == 0:
+        break
+    
+    count = 0
+    
+    for i in range(n + 1, 2 * n + 1):
+        is_prime = True
+
+        for j in range(2, int(sqrt(i)) + 1):
+            if i % j == 0:
+                is_prime = False
+                break
+
+        if is_prime:
+            count += 1
+    
+    print(count)

--- a/nagyum/week6/4948.py
+++ b/nagyum/week6/4948.py
@@ -1,47 +1,19 @@
-"""from math import sqrt
-
+num=123456*2+1 #작거나 같은 값까지 계산해주기 위해
+num_list=[1]*num 
+for i in range(1,num):
+    if i ==1:
+        continue
+    for j in range (2, int(i**0.5)+1):
+        if i%j ==0:
+            num_list[i]=0 #나뉜 다면 소수가 아니니까 리스트 값을 1->0 으로 변경
+            break
+        
 while True:
     n=int(input())
     
-    if n ==0:
+    if n==0:
         break
-    
-    count=0
-    
-    for i in range (1,2*n+1):
-        if i ==1:
-            continue
-        if i==2:
-            count +=1
-            continue
-        else:
-            for j in range(2,int(i**0.5)+1):
-                if i %j==0:
-                    break
-                else:
-                    count +=1
-    print(count)
-    """
-
-from math import sqrt
-
-while True:
-    n = int(input())
-    
-    if n == 0:
-        break
-    
-    count = 0
-    
-    for i in range(n + 1, 2 * n + 1):
-        is_prime = True
-
-        for j in range(2, int(sqrt(i)) + 1):
-            if i % j == 0:
-                is_prime = False
-                break
-
-        if is_prime:
-            count += 1
-    
-    print(count)
+    prime=0
+    for i in range(n+1,2*n+1):
+        prime += num_list[i]
+    print(prime)


### PR DESCRIPTION
## ✏️ 풀이 문제 목록

- BOJ 1316 - 그룹 단어 체커 - 실버 5 - O
- BOJ 11047 - 동전 O - 실버 4 - O
- BOJ 11726 - 2×n 타일링 - 실버 3 - O
- BOJ 4948 - 베르트랑 공준 - 실버 2 - O
- BOJ 14889 - 스타트와 링크 - 실버 1 - O

## BOJ 1316 - 그룹 단어 체커 - 실버 5

### 코드 설명
word 입력 받은 것을 바로 리스트처럼 사용했다. 주어진 단어에서 이어진 단어가 같은 경우는 바로 그룹 단어라고 생각하면 되니 다른 경우만 생각했다. 그래서 i번째와 i+1번째가 다를 경우 i+1부터 단어의 끝까지 새로운 리스트를 만들어서 겹치는 것이 있는지 확인하면 된다 

### 시간 복잡도 계산
O(N^2)

## BOJ 11047 - 동전 O - 실버 4 

### 코드 설명
그리디 알고리즘을 사용해서 풀었다. 입력에서 Ai는 Ai-1의 배수 라는 말이 있어서 즉, 큰 동전은 모두 작은 동전의 배수다. 받은 리스트 reverse 해서 큰 동전부터 처리해나갔다.
### 시간 복잡도 계산
O(NlogN)
## BOJ 11726 - 2×n 타일링 - 실버 3

### 코드 설명
점화식을 구할 수 있다.
n=1 -> 1
n=2-> 2
n=3->3
n=4-> 5
n=5->8
이런식으로 진행 됨으로 i번째= i-1번째 + i-2번째 이다.
근데 dp 리스트를 [0]*n+1 로 선언하니 dp 배열의 크기를 n+1로 초기화하고 있습니다. 그러나 dp[0]의 값을 초기화하지 않았기 때문에 인덱스 0에서 IndexError가 발생해서 [0] *1001로 해결했다.

### 시간 복잡도 계산
O(N)
## BOJ 4948 - 베르트랑 공준 - 실버 2

### 코드 설명
소수를 구하는 것이지만 범위만 2배로 늘어났다고 생각하고 풀었는데 계속 시간 초과가 뜬다. 왜지? 이중 for 문을 도니까 글치,,
에라토스테스의 체 라는 이론에 따르면 숫자의 제곱근까지만 소수인지 확인하면 되니까 확인해야 하는 범위가 줄게 된다.
### 시간 복잡도 계산
O(log N) 잘 모르겠다..
## BOJ 14889 - 스타트와 링크 - 실버 1

### 코드 설명
완전 탐색과 백 트래킹을 사용하는 문제인것 같은데 아직 알고리즘들이 익숙하지 못해서 못 풀었다.

### 시간 복잡도 계산
