### PR TITLE
week6 / jekyoung / python

### DIFF
--- a/jekyoung/week6/11047.py
+++ b/jekyoung/week6/11047.py
@@ -1,0 +1,16 @@
+N, K = map(int, input().split())
+coins = []
+cnt = 0
+
+# 입력받은 동전 가치를 리스트에 저장
+for i in range(N):
+    coins.append(int(input()))
+
+# 가장 큰 가치의 동전부터 사용한다.
+for j in range(N-1, -1, -1):
+    # 남아있는 금액보다 동전의 가치가 작거나 같을 때, 지불 가능
+    if K >= coins[j]:
+        cnt += K//coins[j]
+        K = K%coins[j]
+
+print(cnt)

--- a/jekyoung/week6/11726.py
+++ b/jekyoung/week6/11726.py
@@ -1,0 +1,11 @@
+n = int(input())
+# 메모이제이션을 위한 리스트 생성
+dp = [0]*1001
+dp[1]=1
+dp[2]=2
+
+for i in range(3, n+1):
+    dp[i] = dp[i-1]+dp[i-2]
+
+
+print(dp[n]%10007)

--- a/jekyoung/week6/1316.py
+++ b/jekyoung/week6/1316.py
@@ -1,0 +1,15 @@
+N = int(input())
+
+for i in range(N):
+    word = list(input()) 	#문자를 쪼개서 word 리스트에 저장
+    is_group = True 	#문자를 탐색할 때마다 그룹단어 여부는 초기화
+    
+    for j in range(1, len(word)):
+        if word[j] in word[0:j] and word[j] != word[j-1]:
+        	#word[0:j]에서 word[j] 동일문자가 있되, 붙어 있지 않다면 그룹단어가 아님
+            is_group = False
+    
+    #그룹단어가 아니므로, N -= 1
+    if not is_group: N -= 1
+        
+print(N)

--- a/jekyoung/week6/14889.py
+++ b/jekyoung/week6/14889.py
@@ -1,0 +1,30 @@
+N = int(input())
+S = [list(map(int, input().split())) for i in range(N)]
+visited = [False]*N
+min_diff = float('inf')
+
+def backTracking(depth, index):
+    # 조건을 충족시킨다면, 능력치 비교
+    global min_diff
+    if depth == N//2:
+        start, link = 0, 0
+        for a in range(N):
+            for b in range(N):
+                # True는 스타트팀, False는 링크팀
+                if visited[a] and visited[b]:
+                    start += S[a][b]
+                elif not visited[a] and not visited[b]:
+                    link += S[a][b]
+        # 능력치의 차가 최소인 값을 저장
+        min_diff = min(min_diff, abs(start - link))
+        return
+    
+    # 아직 팀원이 채워지지 않았을 때
+    for j in range(index, N):
+        if not visited[j]:
+            visited[j] = True 
+            backTracking(depth+1, j+1)
+            visited[j] = False  # 방문처리 된 경우에 대해 연산이 끝나고 return 되었다면, 다시 False로 변경
+
+backTracking(0,0)
+print(min_diff)

--- a/jekyoung/week6/4948.py
+++ b/jekyoung/week6/4948.py
@@ -1,0 +1,24 @@
+# 리스트 생성, 초기화
+is_prime=[True]*(123456*2+1)
+is_prime[0]=False
+is_prime[1]=False
+
+# 2부터 시작하여, 해당 수의 배수인 경우 is_prime[j]=False로 저장
+for i in range(2,len(is_prime)):
+    if is_prime[i]==False: continue
+    for j in range(2*i, len(is_prime), i):
+        is_prime[j]=False
+
+
+while True:
+    num = int(input())
+    # 0을 입력하면 종료
+    if num==0:
+        break
+    
+    # 소수의 갯수 초기화
+    count = 0
+    # 입력받은 값을 기준으로 특정 범위 내의 소수 갯수를 구함
+    for a in range(num+1, 2*num+1):
+        if is_prime[a]: count += 1
+    print(count)


### PR DESCRIPTION
## ✏️ 풀이 문제 목록

- BOJ {1316} - {그룹 단어 체커} - 실버 5 - {O}
- BOJ {11047} - {동전 O} - 실버 4 - {O}
- BOJ {11726} - {2*n 타일링} - 실버 3 - {O}
- BOJ {4948} - {베르트랑 공준} - 실버 2 - {O}
- BOJ {14889} - {스타트와 링크} - 실버 1 - {O}

## BOJ {1316} - {그룹 단어 체커} - 실버 5

### 코드 설명
입력받은 단어를 쪼개어 word 리스트에 저장
is_group = True으로 초기화
word[0:j]에서 word[j] 있다면, word[j]와 word[j-1]이 다르다면 그룹단어가 아님 (is_group = False)

### 시간 복잡도 계산
O(N^2)

## BOJ {11047} - {동전 O} - 실버 4

### 코드 설명
오름차순으로 입력받은 동전 가치를 coins 리스트에 저장
cnt = 0
잔액을 가장 큰 가치의 동전으로 나눈 몫을 cnt에 더함 & 잔액은 그 나머지가 됨

### 시간 복잡도 계산
O(N)

## BOJ {11726} - {2*n 타일링} - 실버 3

### 코드 설명
다이나믹 프로그래밍
dp[i] = dp[i-1] + dp[i-2] 점화식 활용

### 시간 복잡도 계산
O(N)

## BOJ {4948} - {베르트랑 공준} - 실버 2

### 코드 설명
입력 제한으로 주어진 범위를 활용하여, 123,456*2+1 길이의 is_prime 리스트(True) 생성 
2부터 반복문 루프를 시작하여, 인덱스가 해당 수의 배수에 해당하는 경우 False 처리
입력받은 숫자에 따른 범위 내 소수(True인 것) 갯수를 구한다.

### 시간 복잡도 계산
O(Nlog(logN))

## BOJ {14889} - {스타트와 링크} - 실버 1

### 코드 설명
백트래킹으로 dfs
인원수만큼 길이의 visited 리스트(False) 생성
스타트팀: True, 링크팀: False -> visited[j]=True 를 세번째 거친 루프에서 if문에 따라 능력치 비교 시작
min함수로 최솟값 갱신

### 시간 복잡도 계산
O(2^n)