### PR TITLE
week 17 / jekyoung / python

### DIFF
--- a/jekyoung/week17/1002.py
+++ b/jekyoung/week17/1002.py
@@ -1,0 +1,28 @@
+import sys
+
+T = int(sys.stdin.readline())
+
+for _ in range (T):
+    x1, y1, r1, x2, y2, r2 = map(int, sys.stdin.readline().split())
+    distance = float(((x1-x2)**2 + (y1-y2)**2)**0.5)
+    
+    # 원의 중심이 동일할 때,
+    if distance == 0:
+        # 동일한 원
+        if r1 == r2: print(-1)
+        # 만나지 않는 두 원
+        else: print(0)
+        continue
+
+    # 원의 중심이 다를 때,
+    sum = r1 + r2
+    sub = abs(r1-r2)
+    if sum == distance or sub == distance:
+        # 접하는 경우
+        print(1)
+    elif sub < distance < sum:
+        # 두 점에서 만나는 경우 
+        print(2)
+    else:
+        # 만나지 않는 경우
+        print(0)

--- a/jekyoung/week17/1011.py
+++ b/jekyoung/week17/1011.py
@@ -1,0 +1,7 @@
+import sys
+
+T = int(sys.stdin.readline())
+
+for _ in range (T):
+    x, y = map(int, sys.stdin.readline().split())
+   

--- a/jekyoung/week17/1011.py
+++ b/jekyoung/week17/1011.py
@@ -4,4 +4,15 @@ T = int(sys.stdin.readline())
 
 for _ in range (T):
     x, y = map(int, sys.stdin.readline().split())
-   
+    distance = y - x
+    tmp = 0     # 이동한 거리
+    cnt = 0     # 공간 장치 이동 횟수
+    moving = 0  # 반복 횟수 (cnt가 홀수이면 +1되는 특징)
+
+    while tmp < distance:
+        cnt += 1
+        if cnt % 2 != 0:
+            moving += 1
+        tmp += moving
+    
+    print(cnt)

--- a/jekyoung/week17/10799.py
+++ b/jekyoung/week17/10799.py
@@ -1,0 +1,31 @@
+import sys
+
+irons_input = list(sys.stdin.readline().strip())
+irons = []
+i=0
+
+# () 레이저를 'R'로 치환
+while i < len(irons_input):
+    if irons_input[i] == '(' and irons_input[i+1] == ')':
+        irons.append('R')
+        i += 2
+    else:
+        irons.append(irons_input[i])
+        i += 1
+
+# 영향을 미치지 않는 R 제거
+temp = ''.join(irons).lstrip('R').rstrip('R')
+irons = list(temp)
+        
+nums = 0    # R의 영향을 받는 막대기의 수
+result = 0
+for i in range(len(irons)):
+    if irons[i] == '(':     # R의 영향을 받는 막대기가 추가된 것
+        nums += 1
+    elif irons[i] == 'R':   # R의 영향을 받는 막대기 수만큼 잘림
+        result += nums
+    else:                   # ')'는 막대기가 끝남을 의미하므로,
+        nums -= 1           # 영향 받는 막대기 수 -1, 
+        result += 1         # R이 없어도 하나의 막대기 조각이 발생
+
+print(result)

--- a/jekyoung/week17/11052.py
+++ b/jekyoung/week17/11052.py
@@ -1,0 +1,17 @@
+import sys
+
+N = int(sys.stdin.readline())
+P = [0] + list(map(int, sys.stdin.readline().split()))
+Max = [0]*(N+1)
+Max[1] = P[1]
+Max[2] = max(P[2], Max[1]*2)
+
+# Max[i]: 합이 i가 되는 두 수(j, i-j)의 Max[] 합으로 표현 가능
+# Max[j]+Max[i-j]의 최댓값이 Max[i]가 된다.
+for i in range (3, N+1):
+    max_value = P[i]
+    for j in range(1, i//2+1):
+        max_value = max(max_value, Max[j]+Max[i-j])
+    Max[i] = max_value
+
+print(Max[N])

--- a/jekyoung/week17/18258.py
+++ b/jekyoung/week17/18258.py
@@ -1,0 +1,49 @@
+import sys
+from collections import deque
+queue = deque()
+
+def push(x):
+    queue.append(x)
+
+def pop():
+    if queue:
+        front = queue.popleft()
+    else:
+        front = -1
+    print(front)
+
+def size():
+    print(len(queue))
+
+def empty():
+    if queue:
+        print(0)
+    else:
+        print(1)
+
+def front():
+    if queue:
+        front = queue.popleft()
+        queue.appendleft(front)
+    else:
+        front = -1
+    print(front)
+
+def back():
+    if queue:
+        back = queue.pop()
+        queue.append(back)
+    else:
+        back = -1
+    print(back)
+
+
+N = int(sys.stdin.readline())
+for _ in range (N):
+    order = sys.stdin.readline().split()
+    if len(order) == 1:
+        getattr(sys.modules[__name__], order[0])()
+    else:
+        func, x = order[0], order[1]
+        getattr(sys.modules[__name__], func)(x)
+        


### PR DESCRIPTION
## ✏️ 풀이 문제 목록

## BOJ {18258} - {큐2} - 실버 4

### 코드 설명
파이썬의 큐를 활용하여 풀이
popleft()는 시간복잡도 O(1)이므로, 시간초과 해결할 수 있다.

### 시간 복잡도, 공간 복잡도 계산
시간복잡도 : O(n)
공간복잡도 : O(1)

## BOJ {1002} - {터렛} - 실버 3

### 코드 설명
원의 중심이 동일한 경우, 동일한 원 or 만나지 않는 두 원으로 나누어 계산
원의 중심이 다른 경우, 접할 때 or 두 점에서 만날 때 or 만나지 않을 때로 나누어 계산

### 시간 복잡도, 공간 복잡도 계산
시간복잡도 : O(1)
공간복잡도 : O(1)

## BOJ {10799} - {쇠막대기} - 실버 2

### 코드 설명
()는 레이저이므로, R로 치환
R이 배열의 양 끝에 위치한다면, 쇠막대기에 영향을 주지 않으므로 제거

num: R의 영향을 받는 막대기의 수

'('이 나타나면 num += 1,
R이 나타나면 영향을 받는 수만큼 잘린 것이므로, result += nums
')'이 나타나면 막대기가 끝나면서 R없이도 조각이 발생하므로, num -= 1, result += nums

### 시간 복잡도, 공간 복잡도 계산
시간복잡도 : O(n)
공간복잡도 : O(n)

## BOJ {11052} - {카드고르기} - 실버 1

### 코드 설명
i개를 갖기 위한 금액의 최대값을 Max[i] 라고 하면,
Max[i]는 i를 이루는 두 수의 Max 값(Max[j], Max[i-j])으로 나타낼 수 있으므로,
Max[j] + Max[i-j] 의 최댓값을 찾으면 된다.

### 시간 복잡도, 공간 복잡도 계산
시간복잡도 : O(n^2)
공간복잡도 : O(n)
## BOJ {1011} - {Fly Me To The Alpha Centauri} - 골드 5

### 코드 설명
아래 블로그를 참고하여 풀었다.
https://newtoner.tistory.com/51

거리에 따른 공간 장치 이동횟수를 구해보면, 1, 2, 3, 3, 4, 4, 5, 5, 5, 6, 6, 6, 7, 7, 7, 7 ... 이 나오는데,
여기서, 공간 장치 이동횟수가 홀수가 되었을 때, 반복되는 횟수가 +1 증가한다.
이 규칙을 활용하여 풀면 된다.

### 시간 복잡도, 공간 복잡도 계산
시간복잡도: O(√n)
공간복잡도: O(1)