### PR TITLE
week 17 / nagyum / python

### DIFF
--- a/nagyum/week17/1002.py
+++ b/nagyum/week17/1002.py
@@ -1,0 +1,22 @@
+import math
+
+T = int(input())
+
+for _ in range(T):
+    x1, y1, r1, x2, y2, r2 = list(map(int, input().split()))
+    
+    # 두 원의 중심 사이의 거리
+    dis = math.sqrt((x1 - x2)**2 + (y1 - y2)**2)
+    
+    if dis == 0:    # 두 원의 중심이 같을 경우
+        if r1 == r2: # 두 원의 크기가 같아 겹치는 경우
+            print(-1)
+        else:                     # 한 원이 다른 원 안에 들어가 있는 경우
+            print(0)
+    else:            # 두 원의 중심이 다를 경우
+        if r1+r2 == dis or abs(r2-r1) == dis:
+            print(1)
+        elif ((abs(r1-r2) < dis) and (dis < r1+r2)):
+            print(2)
+        else:
+            print(0)

--- a/nagyum/week17/1011.py
+++ b/nagyum/week17/1011.py
@@ -1,0 +1,19 @@
+import sys
+input=sys.stdin.readline
+
+t = int(input())
+
+for _ in range(t):
+    x, y = map(int, input().split())
+    
+    distance = y - x 
+    tmp = 0 # 이동 거리
+    cnt = 0 # 공간 장치 이동 횟수
+    moving = 0 # 반복 횟수
+
+    while tmp < distance:
+        cnt += 1
+        if cnt % 2 != 0:
+            moving += 1
+        tmp += moving
+    print(cnt)

--- a/nagyum/week17/10799.py
+++ b/nagyum/week17/10799.py
@@ -1,0 +1,17 @@
+import sys
+input=sys.stdin.readline
+
+bar=list(input())
+answer=0
+stack=[]
+
+for i in range(len(bar)):
+    if bar[i]=="(":
+        stack.append("(")
+    else:
+        if bar[i-1]==")":
+            stack.pop()
+            answer += 1
+        else:
+            stack.pop()
+            answer += len(stack)

--- a/nagyum/week17/11052.py
+++ b/nagyum/week17/11052.py
@@ -1,0 +1,12 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+p = [0] + list(map(int, input().split()))
+dp = [0] * (n + 1)
+
+for i in range(1, n + 1) :
+	for j in range(1, i + 1) :
+		dp[i] = max(dp[i], dp[i-j] + p[j])
+
+print(dp[n])

--- a/nagyum/week17/18258.py
+++ b/nagyum/week17/18258.py
@@ -1,0 +1,33 @@
+import sys
+from collections import deque
+input=sys.stdin.readline
+
+N=int(input())
+queue=deque([])
+
+for i in range (N):
+    com=input().split()
+    if com[0] == 'push':
+        queue.append(com[1])
+    elif com[0] == 'pop':
+        if (len(queue)==0):
+            print('-1')
+        else:
+            print(queue.popleft())
+    elif com[0] == 'size':
+        print(len(queue))
+    elif com[0] == 'empty':
+        if (len(queue)==0):
+            print(1)
+        else:
+            print(0)
+    elif com[0] == 'front':
+        if (len(queue)==0):
+            print('-1')
+        else:
+            print(queue[0])
+    elif com[0] == 'back':
+        if (len(queue)==0):
+            print('-1')
+        else:
+            print(queue[-1])


### PR DESCRIPTION
## ✏️ 풀이 문제 목록

## BOJ {18258} - {큐2} - 실버 4

### 코드 설명
파이썬의 큐를 활용해서 풀었다 
### 시간 복잡도, 공간 복잡도 계산
 O(N)
O(1)
## BOJ {1002} - {터렛} - 실버 3

### 코드 설명
주어진 두 좌표를 원의 중점이라고 생각하고 그 사이의 거리와 원의 반지름끼리의 거리를 비교해 겹치는 점의 갯수를 출력하는 문제였다.
1. 중심이 같고, 반지름도 같을 경우
2. 두 원 중심간의 거리와 반지름 차 또는 합이 같을 경우
3. 두 원 중심간의 거리가 반지름차보다 크거나, 합보다 작은 경우 3가지 경우의 수로 나눠주었다.
### 시간 복잡도, 공간 복잡도 계산
O(N)
O(1)

## BOJ {10799} - {쇠막대기} - 실버 2

### 코드 설명
“(“이 레이저의 시작부분이다.
만약 “)”를 만난다면, 그게 한 철봉의 끝이고, 아니라면 또다른 철봉의 시작이다 라고 풀이 했다.
### 시간 복잡도, 공간 복잡도 계산
O(N)
O(N)
## BOJ {11052} - {카드 구매하기} - 실버 1

### 코드 설명
Dp 문제라서 일단 점화식을 찾았다.
dp[i] = 카드 i개 구매하는 최대 가격 , p[j] = kj개가 들어있는 카드팩 가격 이라고 했을때
점화식이 : 
p[1] + dp[i-1]
p[2] + dp[i-2]
p[3] + dp[i-3]
=> dp[i] = p[j] + dp[i - j]
를 가지고 풀었다.
### 시간 복잡도, 공간 복잡도 계산
O(N^2)
O(N)
## BOJ {1011} - {Fly me to the Alpha Centauri} - 골드 5

### 코드 설명
이게 대체 왜 수학 문제로 분류되는 건지 했는데, 규칙성이 있었다. 
https://newtoner.tistory.com/51 참고한 블로그이다. 
1,2,3,3,4,4,5,5,5,6,6,6,7,7,7,7,
이처럼 공간장치 이동 횟수는 (공간 장치 이동 횟수 % 2) 만큼 증가 했고 공간 장치 이동 횟수가 홀수가 될 때마다 반복되는 횟수가 증가했다.

### 시간 복잡도, 공간 복잡도 계산
O(√N)
O(1)