### PR TITLE
week 18 / jekyoung / python

### DIFF
--- a/jekyoung/week18/14891.py
+++ b/jekyoung/week18/14891.py
@@ -1,0 +1,66 @@
+from collections import deque
+
+
+# 회전시킬 톱니바퀴 번호
+# 회전 방향
+# 극이 다르면 반대방향, 같으면 회전X
+
+wheel_1 = list(input())
+wheel_2 = list(input())
+wheel_3 = list(input())
+wheel_4 = list(input())
+
+K = int(input())
+
+def roll(nth, wheel, dir, is_first):
+    if not nth:
+        if is_first: changed_dir = dir
+        else: changed_dir = (-1)*dir
+        if changed_dir == 1:
+            tail = wheel.pop()
+            return [tail] + wheel, changed_dir
+        elif changed_dir == 0:
+            return wheel, 0
+        else:
+            head = wheel.pop(0)
+            return wheel + [head], changed_dir
+    else:
+        return wheel, 0
+
+    
+
+for _ in range(K):
+    num, direction = map(int, input().split())
+    
+    if wheel_1[2] == wheel_2[6]: first = True
+    else: first = False
+
+    if wheel_2[2] == wheel_3[6]: second = True
+    else: second = False
+
+    if wheel_3[2] == wheel_4[6]: third = True
+    else: third = False
+
+    if num == 1:
+        wheel_1, dir = roll(False, wheel_1, direction, True)
+        wheel_2, dir = roll(first, wheel_2, direction, False)
+        wheel_3, dir = roll(second, wheel_3, dir, False)
+        wheel_4, dir = roll(third, wheel_4, dir, False)
+    elif num == 2:
+        wheel_2, dir = roll(False, wheel_2, direction, True)
+        wheel_1, dir = roll(first, wheel_1, direction, False)
+        wheel_3, dir = roll(second, wheel_3, direction, False)
+        wheel_4, dir = roll(third, wheel_4, dir, False)
+    elif num == 3 :
+        wheel_3, dir = roll(False, wheel_3, direction, True)
+        wheel_4, dir = roll(third, wheel_4, direction, False)
+        wheel_2, dir = roll(second, wheel_2, direction, False)
+        wheel_1, dir = roll(first, wheel_1, dir, False)
+    else:
+        wheel_4, dir = roll(False, wheel_4, direction, True)
+        wheel_3, dir = roll(third, wheel_3, direction, False)
+        wheel_2, dir = roll(second, wheel_2, dir, False)
+        wheel_1, dir = roll(first, wheel_1, dir, False)
+
+
+print(int(wheel_1[0])+2*int((wheel_2[0]))+4*int((wheel_3[0]))+8*int((wheel_4[0])))

--- a/jekyoung/week18/1699.py
+++ b/jekyoung/week18/1699.py
@@ -1,0 +1,14 @@
+import sys
+
+N = int(sys.stdin.readline())
+
+# 각각의 수를 1^2 으로 표현할때가 가장 큰 횟수이기 때문에 인덱스와 동일하게 x로 초기화
+dp = [x for x in range(N+1)]
+
+for i in range(1,N+1):
+    for j in range(1,i):
+        if j*j > i :
+            break
+        if dp[i] > dp[i-j*j] + 1 :
+            dp[i] = dp[i-j*j] + 1
+print(dp[N])

--- a/jekyoung/week18/1904.py
+++ b/jekyoung/week18/1904.py
@@ -1,0 +1,12 @@
+import sys
+
+N = int(sys.stdin.readline())
+
+dp = [0]*(N+1)
+
+# 경우의 수 저장 시, 메모리 초과 -> 15746으로 나눈 나머지를 저장
+for i in range(1,N+1):
+    if i==1 or i==2: dp[i] = i
+    else: dp[i] = (dp[i-2] + dp[i-1])%15746
+
+print(dp[N])

--- a/jekyoung/week18/2003.py
+++ b/jekyoung/week18/2003.py
@@ -1,0 +1,48 @@
+import sys
+
+N, M = map(int, sys.stdin.readline().split())
+A = list(map(int, sys.stdin.readline().split()))
+
+# 투 포인터 알고리즘
+s, e = 0, 0
+cnt = 0
+sum = 0 
+
+while True:
+    # 부분합이 M보다 크거나 같은 경우, sum - A[s] & s++
+    if sum >= M:
+        # M과 같은 경우, cnt++
+        if sum == M:
+            cnt += 1
+        sum -= A[s]
+        s += 1
+    
+    # 부분합이 M보다 작은 경우, sum + A[e] & e++
+    else:
+        # 끝까지 탐색했다면 종료
+        if e == N: break
+        sum += A[e]
+        e += 1
+
+print(cnt)
+
+'''
+
+def sum(num, idx):
+    if idx < N : num += A[idx]
+    else: return False
+ 
+    if num == M : 
+        return True
+    elif num > M :
+        return False
+    else: return sum(num, idx+1)
+
+
+for i in range(N):
+    result = 0
+    if sum(result, i): 
+        cnt += 1
+
+print(cnt)
+'''

--- a/jekyoung/week18/2529.py
+++ b/jekyoung/week18/2529.py
@@ -1,0 +1,36 @@
+import sys
+
+k = int(sys.stdin.readline())
+sign = list(sys.stdin.readline().split())
+
+visited = [False]*10
+min = []
+max = []
+
+def check(i, j, k):
+    if k == '<':
+        return i < j
+    else : 
+        return i > j
+
+def solve(depth, s):
+    global min, max
+    if depth == k+1:
+        if len(min)==0:
+            min = s.copy()
+        else:
+            max = s.copy()
+        return
+    
+    for i in range(10):
+        if not visited[i]:
+            if (depth == 0 or check(s[len(s)-1], i, sign[depth-1])):
+                visited[i] = True
+                s.append(i)
+                solve(depth+1, s)
+                s.pop()
+                visited[i] = False
+
+solve(0, [])
+print(''.join(str(s) for s in max))
+print(''.join(str(s) for s in min))


### PR DESCRIPTION
## ✏️ 풀이 문제 목록

## BOJ {2003} - {수들의 합2} - 실버 4

### 코드 설명
투 포인터 알고리즘 활용
s=0, e=0에서 시작하여,
1) 부분합이 M보다 작은 경우 sum += A[e], e++
2) 부분합이 M보다 크거나 같은 경우, sum -= A[s], s++

### 시간 복잡도, 공간 복잡도 계산
시간복잡도: O(n)
공간복잡도: O(n)

## BOJ {1904} - {01 타일} - 실버 3

### 코드 설명
DP 문제로, dp[i] = dp[i-2] + dp[i-1] 이 성립
경우의 수 저장 시 메모리 초과되므로, 15746으로 나눈 나머지 값을 dp에 저장

### 시간 복잡도, 공간 복잡도 계산
시간복잡도: O(n)
공간복잡도: O(n)

## BOJ {1699} - {제곱수의 합} - 실버 2

### 코드 설명
DP문제로 , dp[i] = min(dp[i], dp[i - jj]+1)이 성립한다.

### 시간 복잡도, 공간 복잡도 계산
시간복잡도: O(n^2)
공간복잡도: O(n)

## BOJ {2529} - {부등호} - 실버 1

### 코드 설명
비교하기 위한 함수를 정의한다. (check)
백트래킹을 활용하여, 정답 배열에 추가될 수 있는 값이 없는 경우 배열 끝의 값을 제거하고 다시 탐색을 진행한다.
k+1 길이의 배열이 처음으로 완성된 값이 min 값이다.
그 이후로 등장하는 배열은 max 값에 저장하여 탐색이 완료될 때까지 max 값을 갱신한다.
min, max를 출력한다. 

### 시간 복잡도, 공간 복잡도 계산
시간복잡도: O(n)
공간복잡도: O(n)

## BOJ {14891} - {톱니바퀴} - 골드 5

### 코드 설명
비교해야 하는 구간을 순서대로, first, second, third라고 하여, 비교 결과(boolean)를 변수에 저장한다.

영향을 주는 바퀴와의 동일 여부, 회전 방향에 따라 특정 바퀴의 배열을 변경하는 함수(roll)를 생성한다. (시계방향 or 반시계 or 회전X)

회전을 시작하는 바퀴의 숫자에 따라, 비교해야 하는 톱니바퀴 순서에 따라 roll함수를 실행한다.

### 시간 복잡도, 공간 복잡도 계산
시간복잡도: O(k)
공간복잡도: O(1)