### PR TITLE
week18 / Sunjin / python

### DIFF
--- a/sunjin/week18/14891.py
+++ b/sunjin/week18/14891.py
@@ -1,0 +1,48 @@
+import sys
+from collections import deque
+input = sys.stdin.readline
+t = [deque(list(map(int,input().rstrip()))) for _ in range(4)] # 톱니 상태 저장
+
+# 톱니 돌리기 
+k = int(input())
+for _ in range(k): 
+	r = [] # ✨ 처음 톱니 상태 저장
+	for i in range(4):
+		r.append([t[i][6],t[i][2]])
+	n,d = map(int,input().split())
+	n = n-1
+    
+    # 왼쪽에 있는 톱니들 돌리기
+	if n != 0 :
+		for i in range(n,0,-1):
+			if r[i][0] != r[i-1][1]:
+				if (n-(i-1))%2 == 0:
+					t[i-1].rotate(d)
+				elif (n-(i-1))%2 != 0:
+					t[i-1].rotate(-1*d)
+			elif r[i][0] == r[i-1][1]:
+				break
+                
+	# 오른쪽에 있는 톱니들 돌리기
+	if n != 3:
+		for i in range(n,3):
+			if r[i][1] != r[i+1][0]:
+				if (n-(i+1))%2 == 0:
+					t[i+1].rotate(d)
+				elif (n-(i+1))%2 != 0:
+					t[i+1].rotate(-1*d)
+			elif r[i][1] == r[i+1][0]:
+				break
+	t[n].rotate(d)
+    
+# 출력
+res = 0
+if t[0][0] == 1:
+	res+=1
+if t[1][0] == 1:
+	res+=2
+if t[2][0] == 1:
+	res+=4
+if t[3][0] ==1:
+	res+=8
+print(res)

--- a/sunjin/week18/1699.py
+++ b/sunjin/week18/1699.py
@@ -1,0 +1,19 @@
+"""
+입력: n
+출력: 제곱수 항의 최소 개수
+제약: 1 <= n <= 100,000
+"""
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+
+dp = [x for x in range (n+1)]
+for i in range(1,n+1):
+    for j in range(1,i):
+        if j*j > i :
+            break
+        if dp[i] > dp[i-j*j] + 1 :
+            dp[i] = dp[i-j*j] + 1
+print(dp[n])

--- a/sunjin/week18/1904.py
+++ b/sunjin/week18/1904.py
@@ -1,0 +1,11 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+dp = [0] * 1000001
+dp[1] = 1
+dp[2] = 2
+
+for k in range(3,n+1):
+    dp[k] = (dp[k-1]+ dp[k-2])%15746
+print(dp[n])

--- a/sunjin/week18/2003.py
+++ b/sunjin/week18/2003.py
@@ -1,0 +1,31 @@
+"""
+입력: n, m / a[1], a[2], ..., a[N]
+출력: 경우의 수
+제약: 1 <= n <= 10,000 / 1 <= m <= 300,000,000 / 1 <= a[x] <= 30,000
+"""
+import sys
+
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+a = list(map(int, input().split()))
+
+left, right = 0, 1
+count = 0
+
+while right <= n and left <= right:
+  sum_nums = a[left:right]
+  total = sum(sum_nums)
+
+  if total == m:
+    count += 1
+
+    right += 1
+  
+  elif total < m:
+    right += 1
+
+  else:
+    left += 1
+
+print(count)

--- a/sunjin/week18/2529.py
+++ b/sunjin/week18/2529.py
@@ -1,0 +1,37 @@
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+ine_sing = list(map(str,input().split()))
+
+visited = [0]*10
+max_ans =""
+min_ans =""
+
+def check(i,j,k):
+    if k=='<':
+        return i<j
+    else:
+        return i>j
+
+def solve(idx,s):
+    global max_ans,min_ans
+
+    if(idx==n+1):
+        if(len(min_ans)==0):
+            min_ans = s
+        else:
+            max_ans = s
+        return
+    for i in range(10):
+        if(visited[i]==0):
+            if(idx==0 or check(s[-1],str(i),ine_sing[idx-1])):
+                visited[i]=True
+                solve(idx+1,s+str(i))
+                visited[i]=False
+
+
+solve(0,"")
+print(max_ans)
+print(min_ans)


### PR DESCRIPTION
## ✏️ 풀이 문제 목록

## BOJ 2003 - 수들의 합 2 - 실버 4
### 코드 설명
구간의 합 < m : 합계를 늘리기 위해, 오른쪽 포인터 이동
구간의 합 > m : 합계를 줄이기 위해, 왼쪽 포인터 이동
구간의 합 = m : count 증가, 오른쪽 포인터 이동
### 시간 복잡도, 공간 복잡도 계산
시간 복잡도: O(N)
공간 복잡도: O(N)

## BOJ 1904 - 01타일 - 실버 3
### 코드 설명
점화식: dp[k] = (dp[k-1]+ dp[k-2])%15746
### 시간 복잡도, 공간 복잡도 계산
시간 복잡도: O(N)
공간 복잡도: dp배열 크기 -> O(N)

## BOJ 1699 - 제곱수의 합 - 실버 2
### 코드 설명
i로 1부터 n까지 돌면서, j는 1부터 i-1까지의 수 중 제곱한 값이 i보다 크지 않아야 한다.
dp[i] > dp[i - j * j] + 1 수식으로, 제곱수 표현할 때 가장 항의 개수가 작은 j를 찾는다.
### 시간 복잡도, 공간 복잡도 계산
시간 복잡도: O(N * root(N))
공간 복잡도: O(N)

## BOJ 2529 - 부등호 - 실버 1
### 코드 설명
완전 탐색으로 부등호 조건을 만족하는 수열을 찾는다.
### 시간 복잡도, 공간 복잡도 계산
시간 복잡도: O(9!)
공간 복잡도: O(N)

## BOJ 14891 - 톱니바퀴 - 골드 5
### 코드 설명
- 왼쪽에 있는 톱니 돌리기
n이 0이 아닐 때, n부터(처음 돌리는 톱니) 0까지(1까지) -1씩 감소하면서 r에 저장해둔 맞물리는 위치를 검사해준다
반대 방향으로 돌 때, 정방향으로 돌 때를 if문을 통해 설정해준다.
만약 톱니가 같은 값으로 맞물린다면 더이상 왼쪽에 있는 톱니를 돌리지 않고 break해준다.
- 오른쪽에 있는 톱니 돌리기
n이 3이 아닐 때, 0부터 n-까지 r에 저장해둔 맞물리는 위치를 검사해준다.
반대 방향으로 돌 때, 정방향으로 돌 때를 if문을 통해 설정해준다.
만약 톱니가 같은 값으로 맞물린다면 더 이상 왼쪽에 있는 톱니를 돌리지 않고 break해준다.
### 시간 복잡도, 공간 복잡도 계산
시간 복잡도: O(N)
공간 복잡도: O(1)